### PR TITLE
suppress compile error because of lack of catkin_LIBRARIES and LIBRARIES

### DIFF
--- a/pr2_teleop_general/CMakeLists.txt
+++ b/pr2_teleop_general/CMakeLists.txt
@@ -14,14 +14,14 @@ catkin_package(
     CATKIN_DEPENDS roscpp actionlib actionlib_msgs geometry_msgs sensor_msgs pr2_msgs pr2_controllers_msgs pr2_controller_manager pr2_mechanism_msgs angles urdf ps3joy pr2_common_action_msgs polled_camera kinematics_msgs
     INCLUDE_DIRS include
     DEPENDS  bullet
-    LIBRARIES
+    LIBRARIES pr2_teleop_general_commander
 )
 
 add_executable(pr2_teleop_general_joystick src/pr2_teleop_general_joystick.cpp)
-target_link_libraries(pr2_teleop_general_joystick)
+target_link_libraries(pr2_teleop_general_joystick  ${catkin_LIBRARIES} pr2_teleop_general_commander)
 
 add_executable(pr2_teleop_general_keyboard src/pr2_teleop_general_keyboard.cpp)
-target_link_libraries(pr2_teleop_general_keyboard)
+target_link_libraries(pr2_teleop_general_keyboard  ${catkin_LIBRARIES} pr2_teleop_general_commander)
 
 add_library(pr2_teleop_general_commander src/pr2_teleop_general_commander.cpp)
 


### PR DESCRIPTION
To pass the compile, I needed to add
- ${catkin_LIBRARIES}
- pr2_teleop_general_commander

I get something like below errors

```
CMakeFiles/pr2_teleop_general_keyboard.dir/src/pr2_teleop_general_keyboard.cpp.o: In function `spin_function()':
pr2_teleop_general_keyboard.cpp:(.text+0x5): undefined reference to `ros::spin()'
CMakeFiles/pr2_teleop_general_keyboard.dir/src/pr2_teleop_general_keyboard.cpp.o: In function `quit(int)':
pr2_teleop_general_keyboard.cpp:(.text+0x2f): undefined reference to `ros::shutdown()'
CMakeFiles/pr2_teleop_general_keyboard.dir/src/pr2_teleop_general_keyboard.cpp.o: In function `main':
pr2_teleop_general_keyboard.cpp:(.text+0xc0): undefined reference to `ros::init(int&, char**, std::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsi
gned int)'
pr2_teleop_general_keyboard.cpp:(.text+0x34d): undefined reference to `ros::console::g_initialized'
pr2_teleop_general_keyboard.cpp:(.text+0x35d): undefined reference to `ros::console::initialize()'
pr2_teleop_general_keyboard.cpp:(.text+0x3a6): undefined reference to `ros::console::initializeLogLocation(ros::console::LogLocation*, std::basic_string<char, std::char_traits<c
har>, std::allocator<char> > const&, ros::console::levels::Level)'
pr2_teleop_general_keyboard.cpp:(.text+0x3e1): undefined reference to `ros::console::setLogLocationLevel(ros::console::LogLocation*, ros::console::levels::Level)'
pr2_teleop_general_keyboard.cpp:(.text+0x3eb): undefined reference to `ros::console::checkLogLocationEnabled(ros::console::LogLocation*)'
pr2_teleop_general_keyboard.cpp:(.text+0x43a): undefined reference to `ros::console::print(ros::console::FilterBase*, void*, ros::console::levels::Level, char const*, int, char 
const*, char const*, ...)'
pr2_teleop_general_keyboard.cpp:(.text+0x517): undefined reference to `GeneralCommander::sendProjectorStartStop(bool)'
pr2_teleop_general_keyboard.cpp:(.text+0x533): undefined reference to `GeneralCommander::sendProjectorStartStop(bool)'
pr2_teleop_general_keyboard.cpp:(.text+0x54f): undefined reference to `GeneralCommander::setLaserMode(GeneralCommander::LaserControlMode)'
pr2_teleop_general_keyboard.cpp:(.text+0x56b): undefined reference to `GeneralCommander::setLaserMode(GeneralCommander::LaserControlMode)'
pr2_teleop_general_keyboard.cpp:(.text+0x587): undefined reference to `GeneralCommander::setLaserMode(GeneralCommander::LaserControlMode)'
pr2_teleop_general_keyboard.cpp:(.text+0x5a3): undefined reference to `GeneralCommander::setHeadMode(GeneralCommander::HeadControlMode)'
pr2_teleop_general_keyboard.cpp:(.text+0x5ca): undefined reference to `GeneralCommander::setHeadMode(GeneralCommander::HeadControlMode)'
pr2_teleop_general_keyboard.cpp:(.text+0x5e1): undefined reference to `GeneralCommander::getHeadMode()'
pr2_teleop_general_keyboard.cpp:(.text+0x634): undefined reference to `GeneralCommander::getHeadMode()'
pr2_teleop_general_keyboard.cpp:(.text+0x67b): undefined reference to `GeneralCommander::getHeadMode()'
pr2_teleop_general_keyboard.cpp:(.text+0x6b7): undefined reference to `GeneralCommander::getHeadMode()'
```
