### PR TITLE
fix the disgnated files location in pr2_mannequin_mode

### DIFF
--- a/pr2_teleop_general/launch/headcart_general_keyboard.launch
+++ b/pr2_teleop_general/launch/headcart_general_keyboard.launch
@@ -1,12 +1,12 @@
 <launch>
 
   <!-- Head controllers for mannequin mode -->
-  <rosparam command="load" file="$(find pr2_mannequin_mode)/head_position_controller_loose.yaml" />
+  <rosparam command="load" file="$(find pr2_mannequin_mode)/config/head_position_controller_loose.yaml" />
   <node pkg="pr2_controller_manager" type="spawner" name="spawn_head_controller"
         args="--stopped head_traj_controller_loose" />
   
   <!-- Trajectory Locks for Mannequin Modes -->
-  <include file="$(find pr2_mannequin_mode)/trajectory_lock.launch"/>
+  <include file="$(find pr2_mannequin_mode)/launch/trajectory_lock.launch"/>
 
   <node pkg="pr2_teleop_general" type="pr2_teleop_general_keyboard" name="headcart_general_keyboard" output="screen">
   	<param name="control_body" type="bool" value="false"/>

--- a/pr2_teleop_general/launch/pr2_teleop_general_joystick.launch
+++ b/pr2_teleop_general/launch/pr2_teleop_general_joystick.launch
@@ -1,12 +1,12 @@
 <launch>
 
   <!--  Arm controllers for mannequin mode -->
-  <rosparam command="load" file="$(find pr2_mannequin_mode)/pr2_arm_controllers_loose.yaml" />
+  <rosparam command="load" file="$(find pr2_mannequin_mode)/config/pr2_arm_controllers_loose.yaml" />
   <node pkg="pr2_controller_manager" type="spawner" name="spawn_arm_controllers"
         args="--stopped r_arm_controller_loose l_arm_controller_loose" />
 
   <!-- Head controllers for mannequin mode -->
-  <rosparam command="load" file="$(find pr2_mannequin_mode)/head_position_controller_loose.yaml" />
+  <rosparam command="load" file="$(find pr2_mannequin_mode)/config/head_position_controller_loose.yaml" />
   <node pkg="pr2_controller_manager" type="spawner" name="spawn_head_controller"
         args="--stopped head_traj_controller_loose" />
  
@@ -21,7 +21,7 @@
   </node>
   
   <!-- Trajectory Locks for Mannequin Modes -->
-  <include file="$(find pr2_mannequin_mode)/trajectory_lock.launch"/>
+  <include file="$(find pr2_mannequin_mode)/launch/trajectory_lock.launch"/>
 
   <node pkg="pr2_tuck_arms_action" type="tuck_arms.py" name="tuck_arms_action" output="screen">
   	<param name="controller_name" type="string" value="arm_controller"/>

--- a/pr2_teleop_general/launch/pr2_teleop_general_joystick_noik.launch
+++ b/pr2_teleop_general/launch/pr2_teleop_general_joystick_noik.launch
@@ -1,17 +1,17 @@
 <launch>
 
   <!--  Arm controllers for mannequin mode -->
-  <rosparam command="load" file="$(find pr2_mannequin_mode)/pr2_arm_controllers_loose.yaml" />
+  <rosparam command="load" file="$(find pr2_mannequin_mode)/config/pr2_arm_controllers_loose.yaml" />
   <node pkg="pr2_controller_manager" type="spawner" name="spawn_arm_controllers"
         args="--stopped r_arm_controller_loose l_arm_controller_loose" />
 
   <!-- Head controllers for mannequin mode -->
-  <rosparam command="load" file="$(find pr2_mannequin_mode)/head_position_controller_loose.yaml" />
+  <rosparam command="load" file="$(find pr2_mannequin_mode)/config/head_position_controller_loose.yaml" />
   <node pkg="pr2_controller_manager" type="spawner" name="spawn_head_controller"
         args="--stopped head_traj_controller_loose" />
  
   <!-- Trajectory Locks for Mannequin Modes -->
-  <include file="$(find pr2_mannequin_mode)/trajectory_lock.launch"/>
+  <include file="$(find pr2_mannequin_mode)/launch/trajectory_lock.launch"/>
 
   <node pkg="pr2_tuck_arms_action" type="tuck_arms.py" name="tuck_arms_action" output="screen">
   	<param name="controller_name" type="string" value="arm_controller"/>

--- a/pr2_teleop_general/launch/pr2_teleop_general_keyboard.launch
+++ b/pr2_teleop_general/launch/pr2_teleop_general_keyboard.launch
@@ -1,17 +1,17 @@
 <launch>
 
   <!--  Arm controllers for mannequin mode -->
-  <rosparam command="load" file="$(find pr2_mannequin_mode)/pr2_arm_controllers_loose.yaml" />
+  <rosparam command="load" file="$(find pr2_mannequin_mode)/config/pr2_arm_controllers_loose.yaml" />
   <node pkg="pr2_controller_manager" type="spawner" name="spawn_arm_controllers"
         args="--stopped r_arm_controller_loose l_arm_controller_loose" />
 
   <!-- Head controllers for mannequin mode -->
-  <rosparam command="load" file="$(find pr2_mannequin_mode)/head_position_controller_loose.yaml" />
+  <rosparam command="load" file="$(find pr2_mannequin_mode)/config/head_position_controller_loose.yaml" />
   <node pkg="pr2_controller_manager" type="spawner" name="spawn_head_controller"
         args="--stopped head_traj_controller_loose" />
   
   <!-- Trajectory Locks for Mannequin Modes -->
-  <include file="$(find pr2_mannequin_mode)/trajectory_lock.launch"/>
+  <include file="$(find pr2_mannequin_mode)/launch/trajectory_lock.launch"/>
 
   <node pkg ="pr2_arm_kinematics" type="pr2_arm_kinematics_node" name="pr2_left_arm_kinematics" output="screen">
    <param name="tip_name" value="l_wrist_roll_link" />

--- a/pr2_teleop_general/launch/pr2_teleop_general_keyboard_noik.launch
+++ b/pr2_teleop_general/launch/pr2_teleop_general_keyboard_noik.launch
@@ -1,17 +1,17 @@
 <launch>
 
   <!--  Arm controllers for mannequin mode -->
-  <rosparam command="load" file="$(find pr2_mannequin_mode)/pr2_arm_controllers_loose.yaml" />
+  <rosparam command="load" file="$(find pr2_mannequin_mode)/config/pr2_arm_controllers_loose.yaml" />
   <node pkg="pr2_controller_manager" type="spawner" name="spawn_arm_controllers"
         args="--stopped r_arm_controller_loose l_arm_controller_loose" />
 
   <!-- Head controllers for mannequin mode -->
-  <rosparam command="load" file="$(find pr2_mannequin_mode)/head_position_controller_loose.yaml" />
+  <rosparam command="load" file="$(find pr2_mannequin_mode)/config/head_position_controller_loose.yaml" />
   <node pkg="pr2_controller_manager" type="spawner" name="spawn_head_controller"
         args="--stopped head_traj_controller_loose" />
   
   <!-- Trajectory Locks for Mannequin Modes -->
-  <include file="$(find pr2_mannequin_mode)/trajectory_lock.launch"/>
+  <include file="$(find pr2_mannequin_mode)/launch/trajectory_lock.launch"/>
 
   <node pkg="pr2_tuck_arms_action" type="tuck_arms.py" name="tuck_arms_action" output="screen">
   	<param name="controller_name" type="string" value="arm_controller"/>


### PR DESCRIPTION
When I tried to launch like below,  

```
roslaunch pr2_teleop_general pr2_teleop_general_joystick.launch
```

I got the below error, so  I fixed each line.

```
error loading <rosparam> tag: 
file does not exist [/home/applications/ros/hydro/src/pr2_apps/pr2_mannequin_mode/pr2_arm_controllers_loose.yaml]
XML is <rosparam command="load" file="$(find pr2_mannequin_mode)/pr2_arm_controllers_loose.yaml"/>
```
- head_position_controller_loose.yaml -> config/head_position_controller_loose.yaml
- pr2_arm_controllers_loose.yaml -> config/pr2_arm_controllers_loose.yaml
- trajectory_lock.launch -> launch/trajectory_lock.launch
