### PR TITLE
Pr2 teleop general for hydro not use move group

### DIFF
--- a/pr2_teleop_general/CMakeLists.txt
+++ b/pr2_teleop_general/CMakeLists.txt
@@ -2,16 +2,12 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(pr2_teleop_general)
 
-find_package(catkin REQUIRED COMPONENTS roscpp actionlib actionlib_msgs geometry_msgs sensor_msgs pr2_msgs pr2_controllers_msgs pr2_controller_manager pr2_mechanism_msgs angles urdf ps3joy pr2_common_action_msgs polled_camera moveit_msgs)
+find_package(catkin REQUIRED COMPONENTS roscpp actionlib actionlib_msgs geometry_msgs sensor_msgs pr2_msgs pr2_controllers_msgs pr2_controller_manager pr2_mechanism_msgs angles urdf ps3joy pr2_common_action_msgs polled_camera moveit_msgs moveit_core moveit_ros_planning eigen_conversions)
 
 include_directories(include ${catkin_INCLUDE_DIRS})
 
-
-
-
-
 catkin_package(
-    CATKIN_DEPENDS roscpp actionlib actionlib_msgs geometry_msgs sensor_msgs pr2_msgs pr2_controllers_msgs pr2_controller_manager pr2_mechanism_msgs angles urdf ps3joy pr2_common_action_msgs polled_camera moveit_msgs
+    CATKIN_DEPENDS roscpp actionlib actionlib_msgs geometry_msgs sensor_msgs pr2_msgs pr2_controllers_msgs pr2_controller_manager pr2_mechanism_msgs angles urdf ps3joy pr2_common_action_msgs polled_camera moveit_msgs moveit_core moveit_ros_planning eigen_conversions
     INCLUDE_DIRS include
     DEPENDS  bullet
     LIBRARIES pr2_teleop_general_commander

--- a/pr2_teleop_general/CMakeLists.txt
+++ b/pr2_teleop_general/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(pr2_teleop_general)
 
-find_package(catkin REQUIRED COMPONENTS roscpp actionlib actionlib_msgs geometry_msgs sensor_msgs pr2_msgs pr2_controllers_msgs pr2_controller_manager pr2_mechanism_msgs angles urdf ps3joy pr2_common_action_msgs polled_camera kinematics_msgs)
+find_package(catkin REQUIRED COMPONENTS roscpp actionlib actionlib_msgs geometry_msgs sensor_msgs pr2_msgs pr2_controllers_msgs pr2_controller_manager pr2_mechanism_msgs angles urdf ps3joy pr2_common_action_msgs polled_camera moveit_msgs)
 
 include_directories(include ${catkin_INCLUDE_DIRS})
 
@@ -11,7 +11,7 @@ include_directories(include ${catkin_INCLUDE_DIRS})
 
 
 catkin_package(
-    CATKIN_DEPENDS roscpp actionlib actionlib_msgs geometry_msgs sensor_msgs pr2_msgs pr2_controllers_msgs pr2_controller_manager pr2_mechanism_msgs angles urdf ps3joy pr2_common_action_msgs polled_camera kinematics_msgs
+    CATKIN_DEPENDS roscpp actionlib actionlib_msgs geometry_msgs sensor_msgs pr2_msgs pr2_controllers_msgs pr2_controller_manager pr2_mechanism_msgs angles urdf ps3joy pr2_common_action_msgs polled_camera moveit_msgs
     INCLUDE_DIRS include
     DEPENDS  bullet
     LIBRARIES pr2_teleop_general_commander
@@ -28,7 +28,7 @@ add_library(pr2_teleop_general_commander src/pr2_teleop_general_commander.cpp)
 
 target_link_libraries(pr2_teleop_general_commander  ${catkin_LIBRARIES})
 add_dependencies(pr2_teleop_general_commander gencpp ${PROJECT_NAME}_gencpp)
-add_dependencies(pr2_teleop_general_commander kinematics_msgs_gencpp)
+add_dependencies(pr2_teleop_general_commander moveit_msgs_gencpp)
 install(TARGETS pr2_teleop_general_joystick pr2_teleop_general_keyboard
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/pr2_teleop_general/include/pr2_teleop_general/pr2_teleop_general_commander.h
+++ b/pr2_teleop_general/include/pr2_teleop_general/pr2_teleop_general_commander.h
@@ -160,10 +160,10 @@ public:
 
 private:
 
-  geometry_msgs::Pose getPositionFromJointsPose(ros::ServiceClient& service_client,  						
-						std::string fk_link,
-						const std::vector<std::string>& joint_names, const std::vector<double>& joint_pos);
-  
+  geometry_msgs::Pose getPositionFromJointsPose(
+                                                std::string fk_link,
+                                                const std::vector<std::string>& joint_names, const std::vector<double>& joint_pos);
+
   void updateWalkAlongAverages();
 
   void jointStateCallback(const sensor_msgs::JointStateConstPtr &jointState);
@@ -216,12 +216,6 @@ private:
 
   ros::ServiceClient tilt_laser_service_;
   ros::ServiceClient switch_controllers_service_;
-  ros::ServiceClient right_arm_kinematics_solver_client_;
-  ros::ServiceClient right_arm_kinematics_forward_client_;
-  ros::ServiceClient right_arm_kinematics_inverse_client_;
-  ros::ServiceClient left_arm_kinematics_solver_client_;
-  ros::ServiceClient left_arm_kinematics_forward_client_;
-  ros::ServiceClient left_arm_kinematics_inverse_client_;
   ros::ServiceClient prosilica_polling_client_;
   ros::Publisher head_pub_;
   ros::Publisher torso_pub_;
@@ -231,7 +225,10 @@ private:
   ros::Subscriber joint_state_sub_;
   ros::Subscriber power_board_sub_;
 
-  ros::Time last_right_wrist_goal_stamp_;  
+  ros::ServiceClient both_arms_kinematics_forward_client_;
+  ros::ServiceClient both_arms_kinematics_inverse_client_;
+
+  ros::Time last_right_wrist_goal_stamp_;
   ros::Time last_left_wrist_goal_stamp_;
 
   double last_torso_vel_;

--- a/pr2_teleop_general/include/pr2_teleop_general/pr2_teleop_general_commander.h
+++ b/pr2_teleop_general/include/pr2_teleop_general/pr2_teleop_general_commander.h
@@ -48,6 +48,8 @@
 #include <pr2_controllers_msgs/JointTrajectoryAction.h>
 #include <pr2_common_action_msgs/TuckArmsAction.h>
 #include <pr2_msgs/PowerBoardState.h>
+#include <moveit/robot_model_loader/robot_model_loader.h>
+#include <moveit/robot_state/robot_state.h>
 
 static const std::string default_arm_controller_name="arm_controller";
 
@@ -225,8 +227,11 @@ private:
   ros::Subscriber joint_state_sub_;
   ros::Subscriber power_board_sub_;
 
-  ros::ServiceClient both_arms_kinematics_forward_client_;
-  ros::ServiceClient both_arms_kinematics_inverse_client_;
+  robot_model_loader::RobotModelLoader robot_model_loader_;
+  moveit::core::RobotModelPtr kinematic_model_;
+  moveit::core::RobotStatePtr kinematic_state_;
+  const moveit::core::JointModelGroup* right_joint_model_group_;
+  const moveit::core::JointModelGroup* left_joint_model_group_;
 
   ros::Time last_right_wrist_goal_stamp_;
   ros::Time last_left_wrist_goal_stamp_;

--- a/pr2_teleop_general/launch/pr2_teleop_general_joystick.launch
+++ b/pr2_teleop_general/launch/pr2_teleop_general_joystick.launch
@@ -2,27 +2,17 @@
 <include file="$(find pr2_moveit_config)/launch/planning_context.launch" />
 
   <!--  Arm controllers for mannequin mode -->
-  <rosparam command="load" file="$(find pr2_mannequin_mode)/pr2_arm_controllers_loose.yaml" />
+  <rosparam command="load" file="$(find pr2_mannequin_mode)/config/pr2_arm_controllers_loose.yaml" />
   <node pkg="pr2_controller_manager" type="spawner" name="spawn_arm_controllers"
         args="--stopped r_arm_controller_loose l_arm_controller_loose" />
 
   <!-- Head controllers for mannequin mode -->
-  <rosparam command="load" file="$(find pr2_mannequin_mode)/head_position_controller_loose.yaml" />
+  <rosparam command="load" file="$(find pr2_mannequin_mode)/config/head_position_controller_loose.yaml" />
   <node pkg="pr2_controller_manager" type="spawner" name="spawn_head_controller"
         args="--stopped head_traj_controller_loose" />
- 
-  <node pkg ="pr2_arm_kinematics" type="pr2_arm_kinematics_node" name="pr2_left_arm_kinematics" output="screen">
-   <param name="tip_name" value="l_wrist_roll_link" />
-   <param name="root_name" value="torso_lift_link" />
-  </node>
-
-  <node pkg="pr2_arm_kinematics" type="pr2_arm_kinematics_node" name="pr2_right_arm_kinematics" output="screen">
-   <param name="tip_name" value="r_wrist_roll_link" />
-   <param name="root_name" value="torso_lift_link" />
-  </node>
   
   <!-- Trajectory Locks for Mannequin Modes -->
-  <include file="$(find pr2_mannequin_mode)/trajectory_lock.launch"/>
+  <include file="$(find pr2_mannequin_mode)/launch/trajectory_lock.launch"/>
 
   <node pkg="pr2_tuck_arms_action" type="tuck_arms.py" name="tuck_arms_action" output="screen">
   	<param name="controller_name" type="string" value="arm_controller"/>

--- a/pr2_teleop_general/launch/pr2_teleop_general_joystick.launch
+++ b/pr2_teleop_general/launch/pr2_teleop_general_joystick.launch
@@ -1,4 +1,5 @@
 <launch>
+<include file="$(find pr2_moveit_config)/launch/planning_context.launch" />
 
   <!--  Arm controllers for mannequin mode -->
   <rosparam command="load" file="$(find pr2_mannequin_mode)/pr2_arm_controllers_loose.yaml" />

--- a/pr2_teleop_general/launch/pr2_teleop_general_keyboard.launch
+++ b/pr2_teleop_general/launch/pr2_teleop_general_keyboard.launch
@@ -1,27 +1,17 @@
 <launch>
 
   <!--  Arm controllers for mannequin mode -->
-  <rosparam command="load" file="$(find pr2_mannequin_mode)/pr2_arm_controllers_loose.yaml" />
+  <rosparam command="load" file="$(find pr2_mannequin_mode)/config/pr2_arm_controllers_loose.yaml" />
   <node pkg="pr2_controller_manager" type="spawner" name="spawn_arm_controllers"
         args="--stopped r_arm_controller_loose l_arm_controller_loose" />
 
   <!-- Head controllers for mannequin mode -->
-  <rosparam command="load" file="$(find pr2_mannequin_mode)/head_position_controller_loose.yaml" />
+  <rosparam command="load" file="$(find pr2_mannequin_mode)/config/head_position_controller_loose.yaml" />
   <node pkg="pr2_controller_manager" type="spawner" name="spawn_head_controller"
         args="--stopped head_traj_controller_loose" />
   
   <!-- Trajectory Locks for Mannequin Modes -->
-  <include file="$(find pr2_mannequin_mode)/trajectory_lock.launch"/>
-
-  <node pkg ="pr2_arm_kinematics" type="pr2_arm_kinematics_node" name="pr2_left_arm_kinematics" output="screen">
-   <param name="tip_name" value="l_wrist_roll_link" />
-   <param name="root_name" value="torso_lift_link" />
-  </node>
-
-  <node pkg="pr2_arm_kinematics" type="pr2_arm_kinematics_node" name="pr2_right_arm_kinematics" output="screen">    
-   <param name="tip_name" value="r_wrist_roll_link" />     
-   <param name="root_name" value="torso_lift_link" />  
-  </node>
+  <include file="$(find pr2_mannequin_mode)/launch/trajectory_lock.launch"/>
 
   <node pkg="pr2_tuck_arms_action" type="tuck_arms.py" name="tuck_arms_action" output="screen">
   	<param name="controller_name" type="string" value="arm_controller"/>

--- a/pr2_teleop_general/launch/pr2_teleop_general_keyboard.launch
+++ b/pr2_teleop_general/launch/pr2_teleop_general_keyboard.launch
@@ -1,5 +1,5 @@
 <launch>
-
+<include file="$(find pr2_moveit_config)/launch/planning_context.launch" />
   <!--  Arm controllers for mannequin mode -->
   <rosparam command="load" file="$(find pr2_mannequin_mode)/config/pr2_arm_controllers_loose.yaml" />
   <node pkg="pr2_controller_manager" type="spawner" name="spawn_arm_controllers"

--- a/pr2_teleop_general/package.xml
+++ b/pr2_teleop_general/package.xml
@@ -28,6 +28,9 @@
   <build_depend>polled_camera</build_depend>
   <build_depend>bullet</build_depend>
   <build_depend>moveit_msgs</build_depend>
+  <build_depend>moveit_core</build_depend>
+  <build_depend>moveit_ros_planning</build_depend>
+  <build_depend>eigen_conversions</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>actionlib</run_depend>
@@ -45,6 +48,9 @@
   <run_depend>polled_camera</run_depend>
   <run_depend>bullet</run_depend>
   <run_depend>moveit_msgs</run_depend>
+  <run_depend>moveit_core</run_depend>
+  <run_depend>moveit_ros_planning</run_depend>
+  <run_depend>eigen_conversions</run_depend>
 
   <!-- <test_depend>roscpp</test_depend> -->
   <!-- <test_depend>actionlib</test_depend> -->

--- a/pr2_teleop_general/package.xml
+++ b/pr2_teleop_general/package.xml
@@ -27,7 +27,7 @@
   <build_depend>pr2_common_action_msgs</build_depend>
   <build_depend>polled_camera</build_depend>
   <build_depend>bullet</build_depend>
-  <build_depend>kinematics_msgs</build_depend>
+  <build_depend>moveit_msgs</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>actionlib</run_depend>
@@ -44,7 +44,7 @@
   <run_depend>pr2_common_action_msgs</run_depend>
   <run_depend>polled_camera</run_depend>
   <run_depend>bullet</run_depend>
-  <run_depend>kinematics_msgs</run_depend>
+  <run_depend>moveit_msgs</run_depend>
 
   <!-- <test_depend>roscpp</test_depend> -->
   <!-- <test_depend>actionlib</test_depend> -->

--- a/pr2_teleop_general/src/pr2_teleop_general_commander.cpp
+++ b/pr2_teleop_general/src/pr2_teleop_general_commander.cpp
@@ -156,12 +156,9 @@ GeneralCommander::GeneralCommander(bool control_body,
   }
   if(control_larm_ || control_rarm_) {
     tuck_arms_client_ = new actionlib::SimpleActionClient<pr2_common_action_msgs::TuckArmsAction>("tuck_arms", true);
+    updateCurrentWristPositions();
   } else {
     tuck_arms_client_ = NULL;
-  }
-
-  if (control_rarm_ || control_larm_){
-    updateCurrentWristPositions();
   }
 
   if(control_prosilica_) {
@@ -918,10 +915,6 @@ void GeneralCommander::sendArmVelCommands(double r_x_vel, double r_y_vel, double
       if(found_ik)
         {
           kinematic_state_->copyJointGroupPositions(right_joint_model_group_, joint_values);
-          for(std::size_t i=0; i < joint_names.size(); ++i)
-            {
-              ROS_INFO("Joint %s: %f", joint_names[i].c_str(), joint_values[i]);
-            }
 
           pr2_controllers_msgs::JointTrajectoryGoal goal;
           goal.trajectory.joint_names = joint_names;
@@ -939,7 +932,7 @@ void GeneralCommander::sendArmVelCommands(double r_x_vel, double r_y_vel, double
         }
       else
         {
-          ROS_INFO("Did not find IK solution");
+          // ROS_INFO("Did not find IK solution");
         }
       ros::Time afterCall = ros::Time::now();
     }
@@ -1009,10 +1002,7 @@ void GeneralCommander::sendArmVelCommands(double r_x_vel, double r_y_vel, double
         if(found_ik)
           {
             kinematic_state_->copyJointGroupPositions(left_joint_model_group_, joint_values);
-            for(std::size_t i=0; i < joint_names.size(); ++i)
-              {
-                ROS_INFO("Joint %s: %f", joint_names[i].c_str(), joint_values[i]);
-              }
+
             pr2_controllers_msgs::JointTrajectoryGoal goal;
             goal.trajectory.joint_names = joint_names;
             goal.trajectory.points.resize(1);
@@ -1027,7 +1017,7 @@ void GeneralCommander::sendArmVelCommands(double r_x_vel, double r_y_vel, double
           }
         else
           {
-            ROS_INFO("Did not find IK solution");
+            // ROS_INFO("Did not find IK solution");
           }
       }
     }


### PR DESCRIPTION
Don't merge this PR yet.( I need to test on real robot)

This doesn't require to launch move_group.launch.
Instead of running move_group, this node will calculate the ik and fk by itself using moveit kinematics API.
I would like to choose whether #12 or this one.
