### PR TITLE
Add face detection launch

### DIFF
--- a/pr2_teleop_general/launch/facedetector_rgb.launch
+++ b/pr2_teleop_general/launch/facedetector_rgb.launch
@@ -1,0 +1,16 @@
+<launch>
+  <arg name="camera" default="head_mount_kinect" />
+  <arg name="depth_ns" default="depth" /> 
+  <arg name="image_topic" default="image_raw" />
+  <arg name="depth_topic" default="image_raw" />
+  <arg name="fixed_frame" default="head_mount_kinect_rgb_link" />
+
+  <include file="$(find face_detector)/launch/face_detector.rgbd.launch"> 
+    <arg name="camera" value="$(arg camera)" />
+    <arg name="depth_ns" value="$(arg depth_ns)" />
+    <arg name="image_topic" value="$(arg image_topic)" />
+    <arg name="depth_topic" value="$(arg depth_topic)" />
+    <arg name="fixed_frame" value="$(arg fixed_frame)" />
+  </include>
+
+</launch>

--- a/pr2_teleop_general/package.xml
+++ b/pr2_teleop_general/package.xml
@@ -36,6 +36,7 @@
   <run_depend>actionlib</run_depend>
   <run_depend>actionlib_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
+  <run_depend>face_detector</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>pr2_msgs</run_depend>
   <run_depend>pr2_controllers_msgs</run_depend>


### PR DESCRIPTION
To run: simply `roslaunch pr2_teleop_general facedetector_rgb.launch`.

To see the face detection result, for instance using a nice [jsk_rviz_plugins](http://wiki.ros.org/jsk_rviz_plugins):

![facedetect_pr2_jsk-rviz](https://cloud.githubusercontent.com/assets/1840401/10435680/482ca8aa-70d6-11e5-90b5-67c508c1674d.png)
