### PR TITLE
Add queue size to trajectory_lock script

### DIFF
--- a/pr2_mannequin_mode/scripts/trajectory_lock.py
+++ b/pr2_mannequin_mode/scripts/trajectory_lock.py
@@ -74,7 +74,7 @@ def callback(msg):
         print "Small: %.4f" % max_error
 
 global pub
-pub = rospy.Publisher("command", trajectory_msgs.msg.JointTrajectory)
+pub = rospy.Publisher("command", trajectory_msgs.msg.JointTrajectory, queue_size=10)
 
 rospy.Subscriber("state", pr2_controllers_msgs.msg.JointTrajectoryControllerState, callback)
 


### PR DESCRIPTION
Add queue_size as to remove following error:
`/opt/ros/indigo/share/pr2_mannequin_mode/scripts/trajectory_lock.py:77: SyntaxWarning: The publisher should be created with an explicit keyword argument 'queue_size'. Please see http://wiki.ros.org/rospy/Overview/Publishers%20and%20Subscribers for more information.
  pub = rospy.Publisher("command", trajectory_msgs.msg.JointTrajectory)`

Size of 10 was selected arbitrary as working.
