### PR TITLE
Only warn the user on outdated repeated messages

### DIFF
--- a/pr2_teleop/src/teleop_pr2.cpp
+++ b/pr2_teleop/src/teleop_pr2.cpp
@@ -209,7 +209,9 @@ class TeleopPR2
   {
     // Do not process the same message twice.
     if(joy_msg->header.stamp == last_processed_joy_message_.header.stamp) {
-        ROS_WARN_THROTTLE(1.0, "Received Joy message with same timestamp multiple times. Ignoring subsequent messages.");
+        // notify the user only if the problem persists
+        if(ros::Time::now() - joy_msg->header.stamp > ros::Duration(5.0/PUBLISH_FREQ))
+            ROS_WARN_THROTTLE(1.0, "Received Joy message with same timestamp multiple times. Ignoring subsequent messages.");
         deadman_ = false;
         return;
     }


### PR DESCRIPTION
dornhege's commit recently added a safety mechanism to ensure
a properly working dead-man switch with the PS2 controller.

However, in some setups this problem appears during normal operation
but does not persist for long. In order to avoid spamming the log
console, we warn the user only if the received messages are additionally
out of date.

The overall safety mechanism still triggers, this only affects the log.

@dornhege: Please have a look, this refines your previous request.