### PR TITLE
remove GetKinematicSolverInfo

### DIFF
--- a/pr2_teleop_general/include/pr2_teleop_general/pr2_teleop_general_commander.h
+++ b/pr2_teleop_general/include/pr2_teleop_general/pr2_teleop_general_commander.h
@@ -216,10 +216,8 @@ private:
 
   ros::ServiceClient tilt_laser_service_;
   ros::ServiceClient switch_controllers_service_;
-  ros::ServiceClient right_arm_kinematics_solver_client_;
   ros::ServiceClient right_arm_kinematics_forward_client_;
   ros::ServiceClient right_arm_kinematics_inverse_client_;
-  ros::ServiceClient left_arm_kinematics_solver_client_;
   ros::ServiceClient left_arm_kinematics_forward_client_;
   ros::ServiceClient left_arm_kinematics_inverse_client_;
   ros::ServiceClient prosilica_polling_client_;


### PR DESCRIPTION
GetKinematicSolverInfo.srv has been removed from moveit_msgs by https://github.com/ros-planning/moveit_msgs/issues/3,
since I'm not sure what is the best way to re-write code without this service, but to write the list of joint names directory