### PR TITLE
added config files for ps4 dualshock controller (using ds4drv)

### DIFF
--- a/pr2_teleop/config/teleop_ps4.yaml
+++ b/pr2_teleop/config/teleop_ps4.yaml
@@ -1,0 +1,29 @@
+# Axes
+axis_vx: 5 #changed from ps3
+axis_vy: 2
+axis_vw: 0
+axis_pan: 0
+axis_tilt: 5 #changed from ps3
+
+# base velocities
+max_vw: 0.8
+max_vx: 0.5
+max_vy: 0.5
+max_vw_run: 1.4
+max_vx_run: 1.0
+max_vy_run: 1.0
+
+# Head 
+max_pan: 2.7
+max_tilt: 1.4
+min_tilt: -0.4
+tilt_step: 0.3
+pan_step: 0.3
+
+# Buttons have changed for PS3 controller mapping 
+# With joystick remapper, this works with all joysticks on "/joy" 
+run_button: 5 # changed from ps3
+torso_dn_button: 1 #changed from ps3
+torso_up_button: 3 #changed from ps3
+head_button: 6 # changed from ps3
+deadman_button: 4 # changed from ps3

--- a/pr2_teleop/launch/teleop_ps4_joystick.launch
+++ b/pr2_teleop/launch/teleop_ps4_joystick.launch
@@ -1,0 +1,21 @@
+<launch>
+
+  <node type="teleop_gripper" pkg="pr2_teleop" name="teleop_gripper_right" output="screen">
+    <param name="open_button" type="int" value="10" />
+    <param name="close_button" type="int" value="11" />
+    <remap from="command" to="r_gripper_controller/command" />
+  </node>
+
+  <node type="teleop_gripper" pkg="pr2_teleop" name="teleop_gripper_left" output="screen">
+    <param name="open_button" type="int" value="0" />
+    <param name="close_button" type="int" value="2" />
+    <remap from="command" to="l_gripper_controller/command" />
+  </node>
+
+  <node type="teleop_pr2" pkg="pr2_teleop" name="pr2_teleop" output="screen">
+    <remap from="cmd_vel" to="base_controller/command" />
+    <rosparam file="$(find pr2_teleop)/config/teleop_ps4.yaml" command="load" />
+  </node>
+
+</launch>
+


### PR DESCRIPTION
ps3 dualshock controller does not work with kernel versions 4.4 and later, added config files that works with the ps4 dualshock controller that is supported in 16.04 and later (using the ds4drv python package: pip install ds4drv)

for now, added separate launch file teleop_ps4_joystick.launch which draws from different config file which has mappings for ps4 dualshock controller. Remaps left hand open/close to joystick buttons instead of left/right arrows which don't show up as buttons on the ps4 controller