### PR TITLE
Fix pr2_mannequin_mode_nohead.launch

### DIFF
--- a/pr2_mannequin_mode/launch/controllers_nohead.launch
+++ b/pr2_mannequin_mode/launch/controllers_nohead.launch
@@ -1,7 +1,8 @@
 <launch>
 
-  <node pkg="pr2_controller_manager" type="pr2_controller_manager"
-        name="controller_stopper" args="stop l_arm_controller r_arm_controller" />
+  <!-- Stop the existing controllers -->
+  <node pkg="pr2_controller_manager" type="unspawner"
+        name="controller_stopper" args="l_arm_controller r_arm_controller" />
 
   <!--  Arm Controllers -->
   <rosparam command="load" file="$(find pr2_mannequin_mode)/config/pr2_arm_controllers_loose.yaml" />

--- a/pr2_mannequin_mode/launch/controllers_nohead.launch
+++ b/pr2_mannequin_mode/launch/controllers_nohead.launch
@@ -4,13 +4,13 @@
         name="controller_stopper" args="stop l_arm_controller r_arm_controller" />
 
   <!--  Arm Controllers -->
-  <rosparam command="load" file="$(find pr2_mannequin_mode)/pr2_arm_controllers_loose.yaml" />
+  <rosparam command="load" file="$(find pr2_mannequin_mode)/config/pr2_arm_controllers_loose.yaml" />
   <node pkg="pr2_controller_manager" type="spawner" name="spawn_arm_controllers"
         args="r_arm_controller_loose l_arm_controller_loose" />
 
   <!--  In this version, to allow working with joystick teleop, we don't turn on the the Head Controllers -->
-<!--  <rosparam command="load" file="$(find pr2_mannequin_mode)/head_position_controller_loose.yaml" /> -->
+<!--  <rosparam command="load" file="$(find pr2_mannequin_mode)/config/head_position_controller_loose.yaml" /> -->
 <!--  <node pkg="pr2_controller_manager" type="spawner" name="spawn_head_controller" -->
-<!--       args="head_traj_controller" /> -->
+<!--       args="head_traj_controller_loose" /> -->
 
 </launch>

--- a/pr2_mannequin_mode/launch/pr2_mannequin_mode_nohead.launch
+++ b/pr2_mannequin_mode/launch/pr2_mannequin_mode_nohead.launch
@@ -4,6 +4,6 @@
   <include file="$(find pr2_mannequin_mode)/launch/controllers_nohead.launch"/>
 
   <!-- Start the scripts to actually lock the arms and head in place -->
-  <include file="$(find pr2_mannequin_mode)/scripts/trajectory_lock.launch"/>
+  <include file="$(find pr2_mannequin_mode)/launch/trajectory_lock.launch"/>
 
 </launch>


### PR DESCRIPTION
We had some old paths in `pr2_mannequin_mode_nohead.launch`, so am fixing them and using `unspawn` instead of `stop` to unify with `pr2_mannequin_mode.launch`.