### PR TITLE
updated tuck_arms.py script to pass tests under python3/noetic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,24 +5,23 @@
 # https://github.com/ros-infrastructure/ros_buildfarm/blob/master/doc/jobs/prerelease_jobs.rst
 # while this doesn't require sudo we don't want to run within a Docker container
 sudo: true
-dist: trusty
+dist: bionic
 language: python
-python:
-  - "3.4"
 env:
   global:
     - JOB_PATH=/tmp/devel_job
     - ABORT_ON_TEST_FAILURE=1
+    - INDEX_URL=https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml    
   matrix:
-    # indigo/lunar is end-of-life distro, so we need to set old ROS buildfarm config_url for eol distros
-    - ROS_DISTRO_NAME=indigo  OS_NAME=ubuntu OS_CODE_NAME=trusty ARCH=amd64 CONFIG_URL_BRANCH=6a93d17dc6
-    - ROS_DISTRO_NAME=kinetic OS_NAME=ubuntu OS_CODE_NAME=xenial ARCH=amd64 CONFIG_URL_BRANCH=production
-    - ROS_DISTRO_NAME=lunar   OS_NAME=ubuntu OS_CODE_NAME=xenial ARCH=amd64 CONFIG_URL_BRANCH=6a93d17dc6
-    - ROS_DISTRO_NAME=melodic OS_NAME=ubuntu OS_CODE_NAME=bionic ARCH=amd64 CONFIG_URL_BRANCH=production
+    - ROS_DISTRO_NAME=kinetic OS_NAME=ubuntu OS_CODE_NAME=xenial ARCH=amd64
+    - ROS_DISTRO_NAME=melodic OS_NAME=ubuntu OS_CODE_NAME=bionic ARCH=amd64
+    - ROS_DISTRO_NAME=noetic OS_NAME=ubuntu OS_CODE_NAME=bionic ARCH=amd64
 #   matrix:
 #     allow_failures:
 #       - env: ROS_DISTRO_NAME=kinetic OS_NAME=ubuntu OS_CODE_NAME=xenial ARCH=amd64
 install:
+  # check python3 compatibility
+  - if [ "${CHECK_PYTHON3_COMPILE}" == "true" ]; then python3 -m compileall -x asmach .; exit $?; fi
   # either install the latest released version of ros_buildfarm
   - pip install ros_buildfarm
   # or checkout a specific branch
@@ -36,12 +35,12 @@ install:
   - mkdir -p $JOB_PATH/ws/src
   - cp -R $TRAVIS_BUILD_DIR $JOB_PATH/ws/src/
   # generate the script to run a pre-release job for that target and repo
-  - generate_prerelease_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/$CONFIG_URL_BRANCH/index.yaml $ROS_DISTRO_NAME default $OS_NAME $OS_CODE_NAME $ARCH  --output-dir $JOB_PATH
+  - generate_prerelease_script.py $INDEX_URL $ROS_DISTRO_NAME default $OS_NAME $OS_CODE_NAME $ARCH  --output-dir $JOB_PATH
   # run the actual job which involves Docker
   - cd $JOB_PATH; sh ./prerelease.sh -y
 script:
   # get summary of test results
   - /tmp/catkin/bin/catkin_test_results $JOB_PATH/ws/test_results --all
-notifications:
-  email: false
+  notifications:
+    email: false
 

--- a/pr2_tuckarm/scripts/tuck_arms.py
+++ b/pr2_tuckarm/scripts/tuck_arms.py
@@ -51,7 +51,7 @@ import rospy
 
 
 def usage():
-    print __doc__ % vars()
+    print (__doc__ % vars())
     rospy.signal_shutdown("Help requested")
 
 


### PR DESCRIPTION
minor update for python3 compatibility, passes prerelease tests:

generate_prerelease_script.py \
  https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml \
  noetic default ubuntu focal amd64 \
  pr2_kinematics \
  --custom-repo \
    pr2_common_actions__custom-2:git:https://github.com/PR2-prime/pr2_common_actions.git:kinetic-devel \
    pr2_apps__custom-3:git:https://github.com/UNR-RoboticsResearchLab/pr2_apps.git:melodic-devel \
  --level 1 \
  --output-dir ./